### PR TITLE
🔧📝 Changed option for common setup, improved README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ For SAML testing:
 * start appium in separate console
 * `npm install`
 * add correct values to `config/appium.js`
-* `npm run setup common`
+* configure `config/common.js`
+  * `npm run setup common` or `npm run setup common -- -h` will show you help
+  * **You need to add `--` to send arguments directly to the setup util** 
 * `npm start`
 
 ### Running specific tests

--- a/utils/setup-common.js
+++ b/utils/setup-common.js
@@ -9,7 +9,7 @@ const file = path.resolve(__dirname, '../config/common.json');
 
 program
   .version(pkg.version)
-  .option('-h, --host <host>', 'RHMAP host')
+  .option('-t, --host <host>', 'RHMAP host')
   .option('-u, --username <username>', 'RHMAP Username')
   .option('-p, --password <password>', 'RHMAP password')
   .option('-e, --environment <environment>', 'RHMAP environment')


### PR DESCRIPTION
Option `-h` for host in setup-common file can't be used. Collision with `-h` option for help.
I've found out, that option `-f`can stay. The problem was, when I've tried to run `npm run setup common -f` without `--`.
@trepel @jhellar Could you do review please?