### PR TITLE
Accept iOS push alert with retry

### DIFF
--- a/test/ios/push.js
+++ b/test/ios/push.js
@@ -4,17 +4,10 @@ function test() {
 
   const self = this;
 
-  step('should enable push', function() {
+  it('should receive notification', function() {
     return self.driver
-      .acceptAlert();
-  });
-
-  step('should send notification', function() {
-    return self.sendPushNotification('test');
-  });
-
-  step('should receive notification', function() {
-    return self.driver
+      .acceptAlert()
+      .then(() => self.sendPushNotification('test'))
       .sleep(10000)
       .elementByName('test').text().should.become('test');
   });


### PR DESCRIPTION
# Motivation
During iOS push testing if receiving notification fails, and retries are enabled, client app is reinstalled on device and when started alert will appear, which is not confirmed. This alert won't disappear until it is confirmed or canceled. Because of that all other iOS tests will fail. [1]

# Changes
Steps in iOS push test have been squashed to one, so that if receiving notification fails, alert is still confirmed.

[1] https://mobile-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/All/job/jhellar-app-test/160/console